### PR TITLE
fix(css): functions with params containing spaces

### DIFF
--- a/lua/splitjoin/util/node.lua
+++ b/lua/splitjoin/util/node.lua
@@ -209,6 +209,7 @@ end
 function Node.join(node, options)
   local replacement = ''
   local sep = options.separator or ','
+  local separator_is_node = options.separator_is_node ~= false
   local open, close = unpack(options.surround or {})
   local padding = options.padding or ''
 
@@ -227,7 +228,7 @@ function Node.join(node, options)
       else
         append(sep, ' ') -- TODO: inner vs outer padding
       end
-    elseif options.separator_is_node == false then
+    elseif not separator_is_node then
       local text = vim.trim(Node.get_text(child)):gsub(sep..'$', '')
       if Node.next_sibling_is(child, close) then
         append(text)

--- a/lua/splitjoin/util/node.lua
+++ b/lua/splitjoin/util/node.lua
@@ -168,7 +168,6 @@ function Node.split(node, options)
       if     type == open then  table.insert(lines, open..'\n')
       elseif type == sep then
         flush_parts()
-        table.insert(lines, '\n')
       elseif type == close then
         flush_parts()
         table.insert(lines, close)

--- a/lua/splitjoin/util/node.lua
+++ b/lua/splitjoin/util/node.lua
@@ -145,19 +145,50 @@ end
 function Node.split(node, options)
   local indent = options.default_indent or '  '
   local sep = options.separator or ','
-  local separator_is_node = options.separator_is_node or true
+  local separator_is_node = options.separator_is_node ~= false
   local open, close = unpack(options.surround or {})
   local lines = {}
 
-  for child in node:iter_children() do
-    local type = child:type()
-    if     type == open then  table.insert(lines, open..'\n')
-    elseif type == sep then   table.insert(lines, (separator_is_node and '\n' or ''))
-    elseif type == close then table.insert(lines, close)
-    else
-      local text = vim.trim(Node.get_text(child)):gsub(sep..'$', '')
-      local line = indent .. text .. sep
-      table.insert(lines, line..(separator_is_node and '\n' or ''))
+  if separator_is_node then
+    -- Group consecutive non-separator children as a single argument
+    -- (e.g. CSS `to bottom` is two nodes but one argument)
+    local current_parts = {}
+
+    local function flush_parts()
+      if #current_parts > 0 then
+        local text = table.concat(current_parts, ' ')
+        local line = indent .. text .. sep
+        table.insert(lines, line..'\n')
+        current_parts = {}
+      end
+    end
+
+    for child in node:iter_children() do
+      local type = child:type()
+      if     type == open then  table.insert(lines, open..'\n')
+      elseif type == sep then
+        flush_parts()
+        table.insert(lines, '\n')
+      elseif type == close then
+        flush_parts()
+        table.insert(lines, close)
+      else
+        local text = vim.trim(Node.get_text(child)):gsub(sep..'$', '')
+        table.insert(current_parts, text)
+      end
+    end
+    flush_parts()
+  else
+    for child in node:iter_children() do
+      local type = child:type()
+      if     type == open then  table.insert(lines, open..'\n')
+      elseif type == sep then   table.insert(lines, '')
+      elseif type == close then table.insert(lines, close)
+      else
+        local text = vim.trim(Node.get_text(child)):gsub(sep..'$', '')
+        local line = indent .. text .. sep
+        table.insert(lines, line..'\n')
+      end
     end
   end
 
@@ -205,7 +236,16 @@ function Node.join(node, options)
         append(text..sep, ' ') -- TODO: inner vs outer padding
       end
     else
-      append(vim.trim(Node.get_text(child)))
+      local text = vim.trim(Node.get_text(child))
+      local next_sib = child:next_sibling()
+      local next_type = next_sib and next_sib:type()
+      -- Add space between consecutive non-separator siblings
+      -- (e.g. CSS `to bottom` are two nodes forming one argument)
+      if next_type and next_type ~= sep and next_type ~= close then
+        append(text, ' ')
+      else
+        append(text)
+      end
     end
   end
   Node.replace(node, replacement)

--- a/test/css_spec.lua
+++ b/test/css_spec.lua
@@ -59,6 +59,36 @@ describe(lang, function()
       '1'
     )
 
+    H.make_suite(lang, 'arguments with multi-word values',
+      d[[
+        background: linear-gradient(to bottom, #d4d3d2, #dbdad9);
+      ]],
+      d[[
+        background: linear-gradient(
+          to bottom,
+          #d4d3d2,
+          #dbdad9
+        );
+      ]],
+      'to bottom'
+    )
+
+    H.make_suite(lang, 'arguments with nested function calls',
+      d[[
+        background: linear-gradient(to bottom, light-dark(#d4d3d2, #333333), light-dark(#dbdad9, #383838), light-dark(#e2e1e0, #3c3c3c), light-dark(#eaeae9, #404040));
+      ]],
+      d[[
+        background: linear-gradient(
+          to bottom,
+          light-dark(#d4d3d2, #333333),
+          light-dark(#dbdad9, #383838),
+          light-dark(#e2e1e0, #3c3c3c),
+          light-dark(#eaeae9, #404040)
+        );
+      ]],
+      'to bottom'
+    )
+
   end)
 
 end)


### PR DESCRIPTION
e.g. this construct
```css
color: linear-gradient(to top, red, green, blue);
```
should split as
```css
color: linear-gradient(
  to top,
  red,
  green,
  blue
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved argument grouping and spacing so multi-token and multi-node arguments are treated as single logical arguments; formatting now inserts appropriate spaces and line breaks for consecutive non-separator parts.

* **Tests**
  * Added tests verifying multi-word CSS arguments and nested function-call arguments format as expected into properly indented multi-line output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->