### PR TITLE
chore: neovim 0.12 readiness

### DIFF
--- a/test/setup.lua
+++ b/test/setup.lua
@@ -35,7 +35,7 @@ end
 function Setup.load(plugin)
   local name = plugin:match '.*/(.*)'
   local package_root = Setup.root '.test/site/pack/deps/start/'
-  if not vim.loop.fs_stat(package_root .. name) then
+  if not vim.uv.fs_stat(package_root .. name) then
     print('Installing ' .. plugin)
     vim.fn.mkdir(package_root, 'p')
     vim.fn.system {


### PR DESCRIPTION
## Summary
- Replace `vim.loop` with `vim.uv` in test setup (deprecated in nvim 0.12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated plugin setup process to use newer Neovim APIs, improving compatibility with current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->