### PR TITLE
fix(html): support splitting elements with element children

### DIFF
--- a/queries/html/splitjoin.scm
+++ b/queries/html/splitjoin.scm
@@ -13,6 +13,12 @@
   (start_tag
     [ "<" ">" ] @splitjoin.html.angle
     (tag_name) @splitjoin.html.tag.start)
+  (end_tag) @splitjoin.html.tag.end)
+
+(element
+  (start_tag
+    [ "<" ">" ] @splitjoin.html.angle
+    (tag_name) @splitjoin.html.tag.start)
   (text) @splitjoin.html.text
   (end_tag) @splitjoin.html.tag.end)
 

--- a/test/html_spec.lua
+++ b/test/html_spec.lua
@@ -130,6 +130,32 @@ describe(lang, function()
       ]],
       'H'
     )
+
+    H.make_suite(lang, 'multiple children',
+      d[[
+      <div><span>A</span><span>B</span></div>
+      ]],
+      d[[
+      <div>
+        <span>A</span>
+        <span>B</span>
+      </div>
+      ]],
+      'div'
+    )
+
+    H.make_suite(lang, 'nested split',
+      d[[
+      <div><a href="#">Link</a></div>
+      ]],
+      d[[
+      <div>
+        <a href="#">Link</a>
+      </div>
+      ]],
+      'div'
+    )
+
   end)
 
 end)


### PR DESCRIPTION
## Summary

- The HTML treesitter query only matched elements with `(text)` children, so splitting elements like `<div><span>A</span></div>` silently did nothing
- Added a general pattern matching any element with `start_tag` + `end_tag`, regardless of child types
- This likely resolves the intermittent error from #30 -- when the query didn't match, subsequent operations on stale nodes could produce `Invalid 'start_col'` errors

Closes #30

## Test plan

- [x] New test: multiple element children split/rejoin
- [x] New test: nested element split/rejoin
- [x] All existing HTML tests pass (14 tests)
- [x] Full suite passes (204 tests)

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>