### PR TITLE
feat(nix): add Nix list support

### DIFF
--- a/lua/splitjoin/languages/nix/defaults.lua
+++ b/lua/splitjoin/languages/nix/defaults.lua
@@ -1,0 +1,13 @@
+local Nix = require'splitjoin.languages.nix.functions'
+
+---@type SplitjoinLanguageConfig
+return {
+
+  nodes = {
+    list_expression = {
+      split = Nix.split_list,
+      join = Nix.join_list,
+    },
+  },
+
+}

--- a/lua/splitjoin/languages/nix/functions.lua
+++ b/lua/splitjoin/languages/nix/functions.lua
@@ -1,0 +1,44 @@
+local Node = require'splitjoin.util.node'
+
+local Nix = {}
+
+function Nix.split_list(node, options)
+  local indent = options.default_indent or '  '
+  local items = {}
+
+  for child in node:iter_children() do
+    local t = child:type()
+    if t ~= '[' and t ~= ']' then
+      table.insert(items, vim.trim(Node.get_text(child)))
+    end
+  end
+
+  if #items < 2 then return end
+
+  local lines = { '[\n' }
+  for _, item in ipairs(items) do
+    table.insert(lines, indent .. item .. '\n')
+  end
+  table.insert(lines, ']')
+
+  Node.replace(node, table.concat(lines, ''))
+  Node.goto_node(node)
+end
+
+function Nix.join_list(node)
+  local text = Node.get_text(node)
+  if not text:find('\n') then return end
+
+  local items = {}
+  for child in node:iter_children() do
+    local t = child:type()
+    if t ~= '[' and t ~= ']' then
+      table.insert(items, vim.trim(Node.get_text(child)))
+    end
+  end
+
+  Node.replace(node, '[ ' .. table.concat(items, ' ') .. ' ]')
+  Node.goto_node(node)
+end
+
+return Nix

--- a/queries/nix/splitjoin.scm
+++ b/queries/nix/splitjoin.scm
@@ -1,0 +1,1 @@
+(list_expression) @splitjoin.target

--- a/test/bootstrap.lua
+++ b/test/bootstrap.lua
@@ -17,6 +17,7 @@ ts.install({
   'jsdoc',
   'json',
   'lua',
+  'nix',
   'python',
   'rust',
   'typescript',

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -88,6 +88,7 @@ local lang_ext = {
   json = "json",
   html = "html",
   lua  = "lua",
+  nix  = "nix",
   py   = "py",
   python = "py",
   rust = "rs",

--- a/test/nix_spec.lua
+++ b/test/nix_spec.lua
@@ -1,0 +1,90 @@
+local d = require'plenary.strings'.dedent
+local H = require'test.helpers'
+
+local lang = 'nix'
+
+describe(lang, function()
+
+  H.make_suite(lang, 'list',
+    d[[
+      buildInputs = [ pkg1 pkg2 pkg3 ];
+    ]],
+    d[[
+      buildInputs = [
+        pkg1
+        pkg2
+        pkg3
+      ];
+    ]],
+    'pkg1'
+  )
+
+  H.make_suite(lang, 'single element list',
+    d[[
+      buildInputs = [ pkg1 ];
+    ]],
+    d[[
+      buildInputs = [ pkg1 ];
+    ]],
+    'pkg1'
+  )
+
+  H.make_suite(lang, 'list with paths',
+    d[[
+      nativeBuildInputs = [ cmake ninja pkg-config ];
+    ]],
+    d[[
+      nativeBuildInputs = [
+        cmake
+        ninja
+        pkg-config
+      ];
+    ]],
+    'cmake'
+  )
+
+  H.make_suite(lang, 'list with function calls',
+    d[[
+      { x = [ (callPackage ./foo.nix {}) pkg2 ]; }
+    ]],
+    d[[
+      { x = [
+        (callPackage ./foo.nix {})
+        pkg2
+      ]; }
+    ]],
+    'callPackage'
+  )
+
+  H.make_suite(lang, 'list with strings',
+    d[=[
+      { x = [ "hello" "world" ]; }
+    ]=],
+    d[=[
+      { x = [
+        "hello"
+        "world"
+      ]; }
+    ]=],
+    'hello'
+  )
+
+  H.make_suite(lang, 'indented list',
+    d[[
+      {
+        buildInputs = [ pkg1 pkg2 pkg3 ];
+      }
+    ]],
+    d[[
+      {
+        buildInputs = [
+          pkg1
+          pkg2
+          pkg3
+        ];
+      }
+    ]],
+    'pkg1'
+  )
+
+end)


### PR DESCRIPTION
## Summary

- Custom split/join handler for Nix `list_expression` nodes, which use space-delimited items instead of commas
- Handles function calls with nested braces (`(callPackage ./foo.nix {})`), string items, path identifiers
- Single-element lists are correctly skipped (no-op)

## Test plan

- [x] Basic list split/rejoin (3 items)
- [x] Single element list (no-op, round-trips unchanged)
- [x] List with path-like identifiers (pkg-config)
- [x] List with parenthesized function calls and nested braces
- [x] List with string items
- [x] Indented list (inside attrset)
- [x] Full suite passes (250 tests)

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Nix language support with automatic list expression formatting capabilities. Seamlessly converts between inline and multiline formats for Nix lists. Handles various list contents including single-element items, attribute paths, function calls, quoted string values, and deeply nested structures with consistent indentation. Includes comprehensive test coverage for all real-world formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->