### PR TITLE
fix: hold cursor position across split/join (v2)

### DIFF
--- a/lua/splitjoin.lua
+++ b/lua/splitjoin.lua
@@ -70,9 +70,11 @@ local function do_splitjoin(op)
     op = Node.get_text(node):find('\n') and 'join' or 'split'
   end
   local saved_cursor = vim.api.nvim_win_get_cursor(0)
+  local hold_ctx = Cursor.hold(0, saved_cursor, node)
   local handler = options and options[op] or Node[op]
   handler(node, options)
-  local restored = Cursor.clamp(0, saved_cursor[1], saved_cursor[2])
+  local restored = Cursor.restore_hold(0, hold_ctx)
+                or Cursor.clamp(0, saved_cursor[1], saved_cursor[2])
   pcall(vim.api.nvim_win_set_cursor, 0, restored)
 end
 

--- a/lua/splitjoin/util/cursor.lua
+++ b/lua/splitjoin/util/cursor.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+local is_in_node_range = vim.treesitter.is_in_node_range
+local get_node_text = vim.treesitter.get_node_text
+
 ---@param bufnr number
 ---@param row number 1-indexed row
 ---@param col number 0-indexed column
@@ -10,6 +13,104 @@ function M.clamp(bufnr, row, col)
   local line = vim.api.nvim_buf_get_lines(bufnr, row - 1, row, false)[1] or ''
   col = math.max(0, math.min(col, math.max(0, #line - 1)))
   return { row, col }
+end
+
+---@param bufnr number
+---@param cursor number[] {row, col} 1-indexed row, 0-indexed col
+---@param node TSNode the construct node before the handler runs
+---@return table|nil hold context for restore_hold, or nil if cursor not in a child
+function M.hold(bufnr, cursor, node)
+  local cursor_row = cursor[1] - 1
+  local cursor_col = cursor[2]
+  local node_srow, node_scol = node:range()
+  local node_type = node:type()
+
+  local nws_total = 0
+  for child in node:iter_children() do
+    if get_node_text(child, bufnr):match('%S') then
+      nws_total = nws_total + 1
+    end
+  end
+
+  local nws_index = 0
+  for child in node:iter_children() do
+    local text = get_node_text(child, bufnr)
+    if text:match('%S') then
+      if is_in_node_range(child, cursor_row, cursor_col) then
+        local csrow, cscol = child:range()
+        local offset
+        if cursor_row == csrow then
+          offset = cursor_col - cscol
+        else
+          offset = cursor_col
+        end
+        return {
+          nws_index = nws_index,
+          is_last = (nws_index == nws_total - 1),
+          offset = math.max(0, offset),
+          node_srow = node_srow,
+          node_scol = node_scol,
+          node_type = node_type,
+          cursor = cursor,
+        }
+      end
+      nws_index = nws_index + 1
+    end
+  end
+  return nil
+end
+
+---@param bufnr number
+---@param ctx table hold context from M.hold()
+---@return number[]|nil {row, col} restored cursor position, or nil if ctx is nil
+function M.restore_hold(bufnr, ctx)
+  if not ctx then
+    return nil
+  end
+
+  local parser = vim.treesitter.get_parser(bufnr)
+  if parser then parser:parse() end
+
+  local new_node = vim.treesitter.get_node({
+    bufnr = bufnr,
+    pos = { ctx.node_srow, ctx.node_scol },
+    ignore_injections = false,
+  })
+
+  while new_node and new_node:type() ~= ctx.node_type do
+    new_node = new_node:parent()
+  end
+
+  if not new_node then
+    return M.clamp(bufnr, ctx.cursor[1], ctx.cursor[2])
+  end
+
+  local target_index = ctx.nws_index
+  if ctx.is_last then
+    local new_total = 0
+    for child in new_node:iter_children() do
+      if get_node_text(child, bufnr):match('%S') then
+        new_total = new_total + 1
+      end
+    end
+    target_index = new_total - 1
+  end
+
+  local nws_count = 0
+  for child in new_node:iter_children() do
+    local text = get_node_text(child, bufnr)
+    if text:match('%S') then
+      if nws_count == target_index then
+        local csrow, cscol = child:range()
+        local first_line = text:match('[^\n]*')
+        local col = math.min(cscol + ctx.offset, cscol + #first_line - 1)
+        return { csrow + 1, math.max(0, col) }
+      end
+      nws_count = nws_count + 1
+    end
+  end
+
+  return M.clamp(bufnr, ctx.cursor[1], ctx.cursor[2])
 end
 
 return M

--- a/lua/splitjoin/util/cursor.lua
+++ b/lua/splitjoin/util/cursor.lua
@@ -25,39 +25,35 @@ function M.hold(bufnr, cursor, node)
   local node_srow, node_scol = node:range()
   local node_type = node:type()
 
-  local nws_total = 0
+  local nws_children = {}
+  local found_index = nil
+  local found_offset = nil
+
   for child in node:iter_children() do
     if get_node_text(child, bufnr):match('%S') then
-      nws_total = nws_total + 1
+      local idx = #nws_children
+      if not found_index and is_in_node_range(child, cursor_row, cursor_col) then
+        local csrow, cscol = child:range()
+        found_index = idx
+        found_offset = math.max(0, cursor_col - cscol)
+      end
+      nws_children[idx + 1] = true
     end
   end
 
-  local nws_index = 0
-  for child in node:iter_children() do
-    local text = get_node_text(child, bufnr)
-    if text:match('%S') then
-      if is_in_node_range(child, cursor_row, cursor_col) then
-        local csrow, cscol = child:range()
-        local offset
-        if cursor_row == csrow then
-          offset = cursor_col - cscol
-        else
-          offset = cursor_col
-        end
-        return {
-          nws_index = nws_index,
-          is_last = (nws_index == nws_total - 1),
-          offset = math.max(0, offset),
-          node_srow = node_srow,
-          node_scol = node_scol,
-          node_type = node_type,
-          cursor = cursor,
-        }
-      end
-      nws_index = nws_index + 1
-    end
+  if not found_index then
+    return nil
   end
-  return nil
+
+  return {
+    nws_index = found_index,
+    is_last = (found_index == #nws_children - 1),
+    offset = found_offset,
+    node_srow = node_srow,
+    node_scol = node_scol,
+    node_type = node_type,
+    cursor = cursor,
+  }
 end
 
 ---@param bufnr number
@@ -77,7 +73,13 @@ function M.restore_hold(bufnr, ctx)
     ignore_injections = false,
   })
 
-  while new_node and new_node:type() ~= ctx.node_type do
+  while new_node do
+    if new_node:type() == ctx.node_type then
+      local sr, sc = new_node:range()
+      if sr == ctx.node_srow and sc == ctx.node_scol then
+        break
+      end
+    end
     new_node = new_node:parent()
   end
 
@@ -85,32 +87,24 @@ function M.restore_hold(bufnr, ctx)
     return M.clamp(bufnr, ctx.cursor[1], ctx.cursor[2])
   end
 
-  local target_index = ctx.nws_index
-  if ctx.is_last then
-    local new_total = 0
-    for child in new_node:iter_children() do
-      if get_node_text(child, bufnr):match('%S') then
-        new_total = new_total + 1
-      end
-    end
-    target_index = new_total - 1
-  end
-
-  local nws_count = 0
+  local nws = {}
   for child in new_node:iter_children() do
-    local text = get_node_text(child, bufnr)
-    if text:match('%S') then
-      if nws_count == target_index then
-        local csrow, cscol = child:range()
-        local first_line = text:match('[^\n]*')
-        local col = math.min(cscol + ctx.offset, cscol + #first_line - 1)
-        return { csrow + 1, math.max(0, col) }
-      end
-      nws_count = nws_count + 1
+    if get_node_text(child, bufnr):match('%S') then
+      nws[#nws + 1] = child
     end
   end
 
-  return M.clamp(bufnr, ctx.cursor[1], ctx.cursor[2])
+  local target = ctx.is_last and nws[#nws] or nws[ctx.nws_index + 1]
+
+  if not target then
+    return M.clamp(bufnr, ctx.cursor[1], ctx.cursor[2])
+  end
+
+  local csrow, cscol = target:range()
+  local first_line = get_node_text(target, bufnr):match('[^\n]*')
+  local max_offset = math.max(0, #first_line - 1)
+  local col = cscol + math.min(ctx.offset, max_offset)
+  return { csrow + 1, math.max(0, col) }
 end
 
 return M

--- a/test/cursor_spec.lua
+++ b/test/cursor_spec.lua
@@ -159,7 +159,7 @@ describe('cursor position', function()
 
       splitjoin.join()
       assert.same('x', H.get_char_at_cursor())
-      assert.same(8, vim.api.nvim_win_get_cursor(0)[2])
+      assert.same({1, 8}, vim.api.nvim_win_get_cursor(0))
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)

--- a/test/cursor_spec.lua
+++ b/test/cursor_spec.lua
@@ -1,167 +1,166 @@
 local H = require'test.helpers'
 
-local d = require'plenary.strings'.dedent
-
 describe('cursor position', function()
 
   after_each(H.cleanup_tmpfiles)
 
   local splitjoin = require'splitjoin'
 
-  -- SPLIT: cursor col should clamp to shortened first line
+  -- HOLD: cursor tracks character across split/join
 
-  describe('split clamps cursor col', function()
+  describe('hold — split tracks character', function()
 
-    it('lua table', function()
-      -- local t = { a = 1, b = 2, c = 3 }
-      --                  ^ col 17 (comma)
-      -- after split, line 1 = "local t = {" (11 chars, cols 0-10)
+    it('lua table comma', function()
       local bufnr = H.setup_buffer('local t = { a = 1, b = 2, c = 3 }\n', 'lua', {1, 17})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 10}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('lua function args', function()
-      -- call(a, b, c)
-      --       ^ col 6 (comma)
-      -- after split, line 1 = "call(" (5 chars, cols 0-4)
+    it('lua function args comma', function()
       local bufnr = H.setup_buffer('call(a, b, c)\n', 'lua', {1, 6})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 4}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('typescript union', function()
-      -- type A = 1|2|3;
-      --           ^ col 10 (first pipe)
-      -- after split, line 1 = "type A =" (8 chars, cols 0-7)
-      local bufnr = H.setup_buffer('type A = 1|2|3;\n', 'typescript', {1, 10})
-      splitjoin.split()
-      assert.same({1, 7}, vim.api.nvim_win_get_cursor(0))
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end)
-
-    it('go struct', function()
-      -- type User struct { Name string; Age int; Email string }
-      --                    ^ col 19 (N of Name)
-      -- after split, line 1 = "type User struct {" (18 chars, cols 0-17)
+    it('go struct field name', function()
       local bufnr = H.setup_buffer('type User struct { Name string; Age int; Email string }\n', 'go', {1, 19})
+      assert.same('N', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 17}, vim.api.nvim_win_get_cursor(0))
+      assert.same('N', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('javascript object', function()
-      -- { one: 1, two: 2, three: 3 }
-      --         ^ col 8 (comma)
-      -- after split, line 1 = "{" (1 char, col 0)
+    it('javascript object comma', function()
       local bufnr = H.setup_buffer('{ one: 1, two: 2, three: 3 }\n', 'javascript', {1, 8})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 0}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('json object', function()
-      -- { "one": 1, "two": 2, "three": 3 }
-      --           ^ col 10 (comma)
-      -- after split, line 1 = "{" (1 char, col 0)
+    it('json object comma', function()
       local bufnr = H.setup_buffer('{ "one": 1, "two": 2, "three": 3 }\n', 'json', {1, 10})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 0}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-  end)
+    it('opening brace stays on opening brace', function()
+      local bufnr = H.setup_buffer('local t = { a = 1, b = 2 }\n', 'lua', {1, 10})
+      assert.same('{', H.get_char_at_cursor())
+      splitjoin.split()
+      assert.same('{', H.get_char_at_cursor())
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
 
-  -- SPLIT: cursor preserved when position is within bounds of new line
-
-  describe('split preserves cursor when within bounds', function()
+    it('closing brace stays on closing brace', function()
+      local bufnr = H.setup_buffer('local t = { a = 1, b = 2 }\n', 'lua', {1, 26})
+      assert.same('}', H.get_char_at_cursor())
+      splitjoin.split()
+      assert.same('}', H.get_char_at_cursor())
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
 
     it('html attrs — cursor on first attribute', function()
-      -- <a id="a" href="#">Hi</a>
-      --    ^ col 3 (i of id)
-      -- after split, line 1 still has id attr, col 3 within bounds
       local bufnr = H.setup_buffer('<a id="a" href="#">Hi</a>\n', 'html', {1, 3})
+      assert.same('i', H.get_char_at_cursor())
       splitjoin.split()
-      assert.same({1, 3}, vim.api.nvim_win_get_cursor(0))
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end)
-
-    it('lua table — cursor at opening brace', function()
-      -- local t = { a = 1, b = 2, c = 3 }
-      --           ^ col 10 ({)
-      -- after split, line 1 = "local t = {" — col 10 within bounds
-      local bufnr = H.setup_buffer('local t = { a = 1, b = 2, c = 3 }\n', 'lua', {1, 10})
-      splitjoin.split()
-      assert.same({1, 10}, vim.api.nvim_win_get_cursor(0))
+      assert.same('i', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
   end)
 
-  -- JOIN: split first, reposition cursor, then join
-  -- This mirrors real usage and ensures the split form matches what join expects
+  -- HOLD: split+join roundtrip
 
-  describe('join after split', function()
+  describe('hold — roundtrip', function()
 
-    it('lua table — comma on row 2 clamps to row 1', function()
+    it('lua table comma roundtrip', function()
       local bufnr = H.setup_buffer('local t = { a = 1, b = 2, c = 3 }\n', 'lua', {1, 17})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      vim.fn.search(',')
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.join()
-      assert.same({1, 7}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('typescript union — pipe on row 2 clamps to row 1', function()
-      local bufnr = H.setup_buffer('type A = 1|2|3;\n', 'typescript', {1, 10})
+    it('lua function args comma roundtrip', function()
+      local bufnr = H.setup_buffer('vim.print("foo", "bar")\n', 'lua', {1, 15})
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.split()
-      vim.fn.search('|')
+      assert.same(',', H.get_char_at_cursor())
       splitjoin.join()
-      assert.same({1, 0}, vim.api.nvim_win_get_cursor(0))
+      assert.same(',', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('html attrs — href on row 2 clamps to row 1', function()
-      local bufnr = H.setup_buffer('<a id="a" href="#">Hi</a>\n', 'html', {1, 3})
+    it('opening brace roundtrip', function()
+      local bufnr = H.setup_buffer('local t = { a = 1, b = 2 }\n', 'lua', {1, 10})
+      assert.same('{', H.get_char_at_cursor())
       splitjoin.split()
-      vim.fn.search('href')
+      assert.same('{', H.get_char_at_cursor())
       splitjoin.join()
-      assert.same({1, 4}, vim.api.nvim_win_get_cursor(0))
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end)
-
-    it('go struct — brace on row 1 stays on row 1', function()
-      local bufnr = H.setup_buffer('type User struct { Name string; Age int; Email string }\n', 'go', {1, 19})
-      splitjoin.split()
-      vim.fn.search('{')
-      splitjoin.join()
-      assert.same({1, 17}, vim.api.nvim_win_get_cursor(0))
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end)
-
-    it('javascript object — comma on row 2 clamps to row 1', function()
-      local bufnr = H.setup_buffer('{ one: 1, two: 2, three: 3 }\n', 'javascript', {1, 8})
-      splitjoin.split()
-      vim.fn.search(',')
-      splitjoin.join()
-      assert.same({1, 8}, vim.api.nvim_win_get_cursor(0))
+      assert.same('{', H.get_char_at_cursor())
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
   end)
 
-  -- JOIN: cursor col preserved when row doesn't change
+  -- HOLD: duplicate content — proves structural indexing, not char matching
 
-  describe('join preserves cursor col on row 1', function()
+  describe('hold — duplicate content', function()
 
-    it('lua table — cursor on opening brace stays', function()
-      local bufnr = H.setup_buffer('local t = { a = 1, b = 2, c = 3 }\n', 'lua', {1, 10})
+    it('cursor on 2nd a in f(a, a, a) stays on 2nd a after split', function()
+      -- f(a, a, a)
+      --      ^ col 5 (2nd a)
+      local bufnr = H.setup_buffer('f(a, a, a)\n', 'lua', {1, 5})
+      assert.same('a', H.get_char_at_cursor())
+
       splitjoin.split()
-      vim.api.nvim_win_set_cursor(0, {1, 10})
+      assert.same('a', H.get_char_at_cursor())
+
+      -- verify it's the 2nd a, not the 1st — cursor should be on row 3
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.same(3, cursor[1])
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('cursor on 3rd 1 in table stays on 3rd 1 after split', function()
+      -- local t = { 1, 1, 1 }
+      --                   ^ col 18 (3rd 1)
+      local bufnr = H.setup_buffer('local t = { 1, 1, 1 }\n', 'lua', {1, 18})
+      assert.same('1', H.get_char_at_cursor())
+
+      splitjoin.split()
+      assert.same('1', H.get_char_at_cursor())
+
+      -- verify it's the 3rd 1 — cursor should be on row 4
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.same(4, cursor[1])
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('roundtrip preserves position with duplicate args', function()
+      -- f(x, x, x)
+      --         ^ col 8 (3rd x)
+      local bufnr = H.setup_buffer('f(x, x, x)\n', 'lua', {1, 8})
+      assert.same('x', H.get_char_at_cursor())
+
+      splitjoin.split()
+      assert.same('x', H.get_char_at_cursor())
+
       splitjoin.join()
-      assert.same({1, 10}, vim.api.nvim_win_get_cursor(0))
+      assert.same('x', H.get_char_at_cursor())
+      assert.same(8, vim.api.nvim_win_get_cursor(0)[2])
+
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 


### PR DESCRIPTION
## Summary

- Implement treesj-compatible "hold" cursor behavior: cursor stays on the same character across split/join transformations
- Track cursor structurally as `(child_index, char_offset)` within the construct node's children, not by character matching
- Falls back to row/col clamping when structural tracking is unavailable

Replaces the v1 "clamp" approach (merged in #46) which behaved like treesj's `cursor_behavior = 'start'` -- cursor jumped to the start of the node instead of tracking the character.

## How it works

Before the handler runs:
1. Iterate the construct node's children, skip whitespace-only nodes
2. Find which child contains the cursor, record its non-whitespace index
3. Record the cursor's character offset within that child's text

After the handler runs:
1. Re-parse the treesitter tree
2. Find the construct node at the same position, walk up to the same type
3. Find the child at the saved index, apply the saved offset
4. Handle trailing separators by tracking `is_last` flag

## Test plan

- [x] 268 tests pass (0 regressions across 15 language suites)
- [x] Comma tracks through split+join roundtrip (Lua table, function args)
- [x] Opening/closing braces track correctly
- [x] **Duplicate content**: `f(a, a, a)` cursor on 2nd `a` stays on 2nd `a` (proves structural indexing, not character matching)
- [x] **Duplicate content**: `{ 1, 1, 1 }` cursor on 3rd `1` stays on 3rd `1` with correct row
- [x] Roundtrip with duplicate args preserves exact column position

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable cursor retention during split/join: operations now preserve the cursor on the same syntactic character even with repeated or changing structure, falling back safely when context is unavailable.

* **Tests**
  * Expanded tests to assert character-based cursor preservation, including roundtrip split+join checks and cases with duplicate tokens to verify correct occurrence tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->